### PR TITLE
fix gcc dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM python:3.7.8-slim
 EXPOSE 8080
 
 RUN pip install -U pip
+RUN apt-get update
+RUN apt-get -y install gcc
 
 COPY requirements.txt app/requirements.txt
 RUN pip install -r app/requirements.txt


### PR DESCRIPTION
The container has a dependency on gcc. Hence, the docker image build will fail with below error:

unable to execute 'gcc': No such file or directory
error: command 'gcc' failed with exit status 1

The fix consists in adding gcc to the container through the dockerfile.